### PR TITLE
Add onfailure and onsuccess actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,45 @@ Add the "auth" entry in cfssl to use HTTP basic auth:
         "password": "passwd"
     },
 
+To post to a Slack channel when cfssl fails to refresh, add a
+"onfailure" section with a "post_to_slack" subsection:
+
+    {
+      "cfssl": {
+        ...
+      },
+      "onfailure": {
+          "post_to_slack": {
+              "token": "TOKEN",
+              "channel": "alerts"
+          }
+      },
+      "output": {
+        ...
+      }
+    }
+
+To execute a command following a successful certificate refresh, add a
+"onsuccess" section with a "execute_command" key:
+
+    {
+      "cfssl": {
+        ...
+      },
+      "onfailure": {
+          "post_to_slack": {
+              "token": "TOKEN",
+              "channel": "alerts"
+          }
+      },
+      "onsuccess": {
+          "execute_command": "true"
+      },
+      "output": {
+        ...
+      }
+    }
+
+If onfailure.post_to_slack and onsuccess.execute_command are defined,
+then a message will also be posted to Slack if that command fails.
+

--- a/cfssl_refresh_cert.py
+++ b/cfssl_refresh_cert.py
@@ -109,13 +109,18 @@ class CFSSLRefreshCert(object):
         """Return hostname, private IP, and public IP."""
         hostname = socket.gethostname()
 
+        # Grab the IP used to connect to 8.8.8.8
+        #
+        # Use this instead of `socket.gethostbyname(socket.getfqdn())`, because
+        # that can be affected by entries in /etc/hosts.
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.connect(("8.8.8.8", 80))
         private_ip_addr = s.getsockname()[0]
         s.close()
 
+        # Ask a public entity what IP is connecting to it.
         public_ip_addr = None
-        resp = requests.get("http://api.ipify.org")
+        resp = requests.get("https://api.ipify.org")
         if resp.status_code == 200:
             public_ip_addr = resp.text
 

--- a/cfssl_refresh_cert.py
+++ b/cfssl_refresh_cert.py
@@ -2,8 +2,11 @@
 
 import json
 import os
+import socket
 import requests
 import click
+import subprocess
+import shlex
 
 
 class CFSSLRefreshCert(object):
@@ -42,12 +45,54 @@ class CFSSLRefreshCert(object):
             resp.raise_for_status()
         except requests.exceptions.RequestException as e:
             print "cfssl refresh failed! {}".format(e)
+
+            if "onfailure" in self.config:
+                if "post_to_slack" in self.config["onfailure"]:
+
+                    msg_lines = [
+                        "exception: `{}`".format(e),
+                        "request:",
+                        "```",
+                        "{}".format(
+                            json.dumps(self.config["cfssl"]["request"],
+                                       indent=2)),
+                        "```"
+                        ]
+
+                    self._post_to_slack("cfssl refresh failed!", msg_lines)
+
             return False
 
         r = resp.json()
 
         self._write_out_cert_files(r["result"]["certificate"],
                                    r["result"]["private_key"])
+
+        if "onsuccess" in self.config:
+            if "execute_command" in self.config["onsuccess"]:
+                args = shlex.split(
+                    self.config["onsuccess"]["execute_command"]
+                )
+
+                child = subprocess.Popen(args, stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE)
+                stdout, stderr = child.communicate()
+
+                if child.returncode != 0:
+                    if "onfailure" in self.config:
+                        if "post_to_slack" in self.config["onfailure"]:
+                            msg_lines = [
+                                "args: `{}`".format(args),
+                                "rc: {}".format(child.returncode),
+                                "stdout: `{}`".format(stdout.strip()),
+                                "stderr: `{}`".format(stderr.strip()),
+                                ]
+
+                            self._post_to_slack(
+                                "post cfssl refresh execute command failed!",
+                                msg_lines)
+
+                    return False
 
         return True
 
@@ -59,6 +104,51 @@ class CFSSLRefreshCert(object):
             fp.write(private_key)
 
         os.chmod(self.config["output"]["key"], 0600)
+
+    def _get_machine_info(self):
+        """Return hostname, private IP, and public IP."""
+        hostname = socket.gethostname()
+
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        private_ip_addr = s.getsockname()[0]
+        s.close()
+
+        public_ip_addr = None
+        resp = requests.get("http://api.ipify.org")
+        if resp.status_code == 200:
+            public_ip_addr = resp.text
+
+        return hostname, private_ip_addr, public_ip_addr
+
+    def _post_to_slack(self, title, message_lines):
+        """Assuming Slack is in our configuration, post a message there."""
+        slack_config = self.config["onfailure"]["post_to_slack"]
+        url = "https://hooks.slack.com/services/{}"
+        url = url.format(slack_config["token"])
+
+        hostname, private_ip, public_ip = self._get_machine_info()
+
+        standard_info = [
+            "*{}*".format(title),
+            "hostname: {}".format(hostname),
+            "private ip: {}".format(private_ip),
+            "public ip: {}".format(public_ip),
+            ]
+
+        message_text = "\n".join(standard_info + message_lines)
+
+        post_body = {
+            "channel": slack_config["channel"],
+            "text": message_text,
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+        }
+
+        resp = requests.post(url, json=post_body, headers=headers)
+        resp.raise_for_status()
 
 
 @click.command()


### PR DESCRIPTION
Adds posting to Slack if the CFSSL refresh fails.

Also adds executing a command following a successful certificate
refresh. If posting to Slack is configured, a failure to execute the
onsuccess command will also post to Slack.