### PR TITLE
specify your own ca bundle

### DIFF
--- a/cfssl_refresh_cert.py
+++ b/cfssl_refresh_cert.py
@@ -40,6 +40,9 @@ class CFSSLRefreshCert(object):
             kwargs["auth"] = (self.config["cfssl"]["auth"]["user"],
                               self.config["cfssl"]["auth"]["password"])
 
+        if "ca_bundle" in self.config["cfssl"]:
+            kwargs["verify"] = self.config["cfssl"]["ca_bundle"]
+
         try:
             resp = requests.post(url, json=d, **kwargs)
             resp.raise_for_status()

--- a/config.json
+++ b/config.json
@@ -15,7 +15,8 @@
         "testpost.com"
       ],
       "expiry": "876000h"
-    }
+    },
+    "ca_bundle" : "/etc/ssl/certs/ca-certificates.crt"
   },
   "output": {
     "cert": "server.pem",

--- a/test_cfssl_refresh_cert.py
+++ b/test_cfssl_refresh_cert.py
@@ -209,7 +209,7 @@ def test_get_machine_info_ok():
         mock_socket_obj.getsockname.return_value = ["private"]
 
         with requests_mock.mock() as m:
-            m.get("http://api.ipify.org", text="public")
+            m.get("https://api.ipify.org", text="public")
 
             machine_info = refresher._get_machine_info()
 


### PR DESCRIPTION
By default requests trusts a predefined list of ca certs. If you add another cert to your trusted store, you need to explicitly tell requests that this is ok

@jmpesp  